### PR TITLE
Update IO#write return type

### DIFF
--- a/src/lib/ios/pipe.cr
+++ b/src/lib/ios/pipe.cr
@@ -26,14 +26,25 @@ module Cli::Ios
       end
     end
 
-    # Implements `IO#write`.
-    def write(slice : Slice(UInt8)) : Int64
-      if io = @writer
-        io.write slice
-      else
-        raise Closed.new("writer")
+    {% if compare_versions(Crystal::VERSION, "0.35.0") == 0 %}
+      # Implements `IO#write`.
+      def write(slice : Slice(UInt8)) : Int64
+        if io = @writer
+          io.write slice
+        else
+          raise Closed.new("writer")
+        end
       end
-    end
+    {% else %}
+      # Implements `IO#write`.
+      def write(slice : Slice(UInt8)) : Nil
+        if io = @writer
+          io.write slice
+        else
+          raise Closed.new("writer")
+        end
+      end
+    {% end %}
 
     # :nodoc:
     def close


### PR DESCRIPTION
This will keep compatibility for 0.35.0 and 0.35.1 at the same time.